### PR TITLE
Typo and url fix

### DIFF
--- a/srfi-181.html
+++ b/srfi-181.html
@@ -110,8 +110,8 @@ retrieve the id from a port.</p></li>
 are procedures that behave as specified below.
 <li><p>The <i>get-position</i> and <i>set-position!</i>
 arguments may be procedures or <code>#f</code>, in which case calls to
-<a href="http://srfi.schemers.org/scheme-requests-for-implementation">
-SRFI 191</a> <code>port-position</code> and <code>set-port-position!</code>
+<a href="https://srfi.schemers.org/srfi-192/srfi-192.html">
+SRFI 192</a> <code>port-position</code> and <code>set-port-position!</code>
 respectively on the procedures are errors.
 <li><p>The <i>close</i> argument may be a procedure
 that takes no arguments


### PR DESCRIPTION
In "Specification", it referred port posititioning srfi as SRFI-191, and referenced url was nonexistent.